### PR TITLE
Add godoc badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GoDoc](https://pkg.go.dev/badge/github.com/tigerbeetle/tigerbeetle-go?status.svg)](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go?tab=doc)
+
 # tigerbeetle-go
 This repo has been automatically generated from
 [tigerbeetle/tigerbeetle@73bbc1a32ba2513e369764680350c099fe302285](https://github.com/tigerbeetle/tigerbeetle/commit/73bbc1a32ba2513e369764680350c099fe302285)


### PR DESCRIPTION
Add godoc badge

Example:

[![GoDoc](https://pkg.go.dev/badge/github.com/tigerbeetle/tigerbeetle-go?status.svg)](https://pkg.go.dev/github.com/tigerbeetle/tigerbeetle-go?tab=doc)